### PR TITLE
쿼리문 수정

### DIFF
--- a/src/main/java/com/busanit/busan_subway_project/repo/ScheduleRepo.java
+++ b/src/main/java/com/busanit/busan_subway_project/repo/ScheduleRepo.java
@@ -15,7 +15,9 @@ public interface ScheduleRepo extends JpaRepository<Schedule, Integer> {
     @Query(value = "SELECT * FROM schedule s WHERE s.continuity = " +
             "(SELECT sc.continuity FROM schedule sc WHERE sc.direction = :direction " +
             "AND sc.day = :day AND sc.scode = :start " +
-            "AND sc.arrival_time >= :time LIMIT 1) " +
+            "AND sc.arrival_time >= :time " +
+            "order by arrival_time " +
+            "LIMIT 1) " +
             "AND s.scode BETWEEN :small AND :big " +
             "ORDER BY s.schedule_id", nativeQuery = true)
     List<Schedule> findSchedules(@Param("start") int start,


### PR DESCRIPTION
- 기존 쿼리문
```
select * from schedule 
where continuity = ( select continuity 
from schedule 
where direction=1 and day=1 and scode=101
and arrival_time>=current_time() limit 1) 
and scode between 101 and 110;
```
    1. 문제 : 데이터가 모두 일관된 규칙을 가지고 정렬되어있지 않음
    2. 해결 : 첫 번째 쿼리문에서 limit 1 걸기 전에, 조건문을 arrival_time 기준으로 정렬 조건 하나 더 넣어서 -> 현재시간 기준 출발지의 가장 빠른 continuity 를 찾는 것으로 진행

```
select * from schedule 
where continuity = ( select continuity 
from schedule 
where direction=1 and day=1 and scode=101
and arrival_time>=current_time() order by arrival_time limit 1) 
and scode between 101 and 110;
```